### PR TITLE
configure: default newer versions to latest version instead of 4.00.1

### DIFF
--- a/configure
+++ b/configure
@@ -108,6 +108,11 @@ check_package EXIT findlib "Hu! You have ocamlfind but not findlib? Something is
 check_package EXIT yojson "Install yojson"
 MAGIC_VERSION=$(ocamlfind c -config | grep cmi_magic_number|cut -d' ' -f2)
 
+if [ "Caml1999I017" != "`echo -e 'Caml1999I017\n$MAGIC_VERSION' | sort -V | head -n1`" ]; then
+    OCAML_VERSION="ocaml_402"
+    OCAML_VERSION_MESSAGE="Newer, defaulting to 4.02.0"
+fi
+
 case "$MAGIC_VERSION" in
   "Caml1999I015")
     OCAML_VERSION="ocaml_401"


### PR DESCRIPTION
Merlin would not compile with ocaml 4.03.0+trunk because of deprecated functions.
It's probably better to make newer versions use the latest one than the oldest one.

In my commit, some values are hardcoded and should probably be changed to variables to make it easier to maintain.