### PR TITLE
Revised commits for Windows/mingw32

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+configure eol=lf
+*.sh eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ emacs/merlin.elc
 *.cm?
 *.cm??
 ocamlmerlin
+ocamlmerlin.exe
 ._d
 ._ncdi
 

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ distclean: clean
 
 install-binary: $(TARGET)
 	install -d $(BIN_DIR)
-	install $(TARGET) $(BIN_DIR)/ocamlmerlin
+	install $(TARGET)$(EXE) $(BIN_DIR)/ocamlmerlin$(EXE)
 
 install-share: $(TARGET_EMACS)
 	install -d $(SHARE_DIR)

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ install-share: $(TARGET_EMACS)
 	install -d $(SHARE_DIR)
 	install -d $(SHARE_DIR)/emacs/site-lisp
 	install -m 644 emacs/merlin.el $(SHARE_DIR)/emacs/site-lisp/merlin.el
-	-install -m 644 emacs/merlin.elc $(SHARE_DIR)/emacs/site-lisp/merlin.elc
+	test -f emacs/merlin.elc && install -m 644 emacs/merlin.elc $(SHARE_DIR)/emacs/site-lisp/merlin.elc || true
 	install -m 644 emacs/merlin-iedit.el $(SHARE_DIR)/emacs/site-lisp/merlin-iedit.el
 
 install-vim:

--- a/configure
+++ b/configure
@@ -14,9 +14,15 @@ fi
 
 EXIT=0
 
-COL_CLEAR=$(tput sgr0)
-COL_RED=$(tput setf 4)
-COL_GREEN=$(tput setf 2)
+if which tput > /dev/null 2>&1 ; then
+  COL_CLEAR=$(tput sgr0)
+  COL_RED=$(tput setf 4)
+  COL_GREEN=$(tput setf 2)
+else
+  COL_CLEAR=
+  COL_RED=
+  COL_GREEN=
+fi
 
 check_package()
 {

--- a/configure
+++ b/configure
@@ -167,8 +167,17 @@ To customize directories, use:
 For more informations rerun with --help.
 END
 
-rm -f "$PWD/src/ocaml" 2>&1 >/dev/null &&
-  ln -sf "$PWD/src/$OCAML_VERSION" "$PWD/src/ocaml"
+SYSTEM=$(ocamlfind c -config | grep system|cut -d' ' -f2)
+case "$SYSTEM" in
+  mingw*|win*)
+    rm -rf "$PWD/src/ocaml" 2>&1 >/dev/null &&
+      cp -R "$PWD/src/$OCAML_VERSION" "$PWD/src/ocaml"
+    ;;
+  *)
+    rm -f "$PWD/src/ocaml" 2>&1 >/dev/null &&
+      ln -sf "$PWD/src/$OCAML_VERSION" "$PWD/src/ocaml"
+    ;;
+esac
 
 mkdir -p "$PWD/src/config"
 

--- a/configure
+++ b/configure
@@ -172,6 +172,18 @@ rm -f "$PWD/src/ocaml" 2>&1 >/dev/null &&
 
 mkdir -p "$PWD/src/config"
 
+OS_TYPE=$(ocamlfind c -config | grep os_type|cut -d' ' -f2)
+
+# 64-bit Windows also has OS_TYPE = Win32
+case "$OS_TYPE" in
+  Win32)
+    EXE=.exe
+    ;;
+  *)
+    EXE=
+    ;;
+esac
+
 if [ -d "$BIN_DIR" ]; then
 
   cat >Makefile.config <<END
@@ -182,6 +194,7 @@ NATIVE=$NATIVE
 WITH_BIN_ANNOT=$WITH_BIN_ANNOT
 WITH_VIMBUFSYNC=$WITH_VIMBUFSYNC
 ENABLE_COMPILED_EMACS_MODE=$ENABLE_COMPILED_EMACS_MODE
+EXE=$EXE
 END
 
   if [ -n "$VERSION_STRING" ]; then


### PR DESCRIPTION
Finally found some time for upgrading Merlin from the patched 1.6 I'd been using. Patches very similar to those for #194 (some issues had already been fixed or become irrelevant) only as I'm a bit less unfamiliar with git now, I've broken the changes into multiple commits for easier cherry picking if necessary.
An adapted version of this branch also compiles against v2.2 (the whitespace clean-up of vim/merlin/autoload/merlin.py in 8c28e236 means the patch doesn't apply cleaning against v2.2)
I've tested it with gVim 7.4.752 x64 on Windows 7 with Python 2.7.10/3.4.3 for OCaml 4.02.2 i686-w64-mingw32 and it seems to be working beautifully.
a3b240b is critical for building with native Windows ports as ln isn't available
acc4ceb is critical for Vim support on Windows - since reporting that in #194, I've discovered that it is indeed a long-standing bug in Python (and the code is commented accordingly)
Remaining commits, at least with a very current Cygwin, seem to be cosmetic.