### PR TITLE
Add alias for `merlin-send-command-async`

### DIFF
--- a/emacs/merlin-compat.el
+++ b/emacs/merlin-compat.el
@@ -12,6 +12,7 @@
 (defalias 'merlin--completion-bounds      'merlin/completion-bounds)
 (defalias 'merlin--buffer-substring       'merlin/buffer-substring)
 (defalias 'merlin-sync-to-point           'merlin/sync-to-point)
+(defalias 'merlin-send-command-async      'merlin/send-command-async)
 (defalias 'merlin--completion-split-ident 'merlin/completion-split-ident)
 (defalias 'merlin--completion-data        'merlin/complete)
 (defalias 'merlin--completion-prefix      'merlin/completion-prefix)


### PR DESCRIPTION
Hi:
I've added a compatibility alias for `merlin-send-command-async` which was renamed in 4817aa94fec4abdbbd06f5c57c117078a2e0eaf4, and this function is currently used in `flycheck-ocaml.el`