### PR TITLE
Add jump command

### DIFF
--- a/Makefile.ocamlmakefile
+++ b/Makefile.ocamlmakefile
@@ -195,6 +195,8 @@ SOURCES = \
 	src/analysis/completion.ml        \
 	src/analysis/outline.mli          \
 	src/analysis/outline.ml           \
+	src/analysis/jump.mli             \
+	src/analysis/jump.ml              \
 	$(TYPER)/tast_helper.ml           \
 	src/analysis/destruct.mli         \
 	src/analysis/destruct.ml          \

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1517,6 +1517,33 @@ loading"
            (select-window (display-buffer (car r)))))
     (when r (goto-char (cdr r)))))
 
+;;;;;;;;;;
+;; JUMP ;;
+;;;;;;;;;;
+
+(defun merlin/jump (&optional target)
+  "Jump to the TARGET"
+  (let ((result (merlin/send-command
+                  (list 'jump (if (equal target "") "fun,let,module,match" target)
+                        'at (merlin/unmake-point (point))))))
+    (unless result
+      (error "Not found. (Check *Messages* for potential errors)"))
+    (unless (listp result)
+      (error result))
+    result))
+
+(defun merlin-jump (&optional target)
+  "Jump to enclosing fun, let, module or match.
+
+Any combination of the above may be entered, separated by spaces, ex.:
+
+fun let or module or module fun match
+
+Empty string defaults to jumping to all these."
+  (interactive "sfun, let, module or match > ")
+  (merlin/sync-to-end)
+  (merlin--goto-file-and-point (merlin/jump target)))
+
 ;;;;;;;;;;;;;;
 ;; DOCUMENT ;;
 ;;;;;;;;;;;;;;

--- a/src/analysis/jump.ml
+++ b/src/analysis/jump.ml
@@ -1,0 +1,160 @@
+(* {{{ COPYING *(
+
+  This file is part of Merlin, an helper for ocaml editors
+
+  Copyright (C) 2013 - 2014  Frédéric Bour  <frederic.bour(_)lakaban.net>
+                             Thomas Refis  <refis.thomas(_)gmail.com>
+                             Simon Castellan  <simon.castellan(_)iuwt.fr>
+                             Tomasz Kołodziejski  <tkolodziejski(_)gmail.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  The Software is provided "as is", without warranty of any kind, express or
+  implied, including but not limited to the warranties of merchantability,
+  fitness for a particular purpose and noninfringement. In no event shall
+  the authors or copyright holders be liable for any claim, damages or other
+  liability, whether in an action of contract, tort or otherwise, arising
+  from, out of or in connection with the software or the use or other dealings
+  in the Software.
+
+)* }}} *)
+
+open Std
+
+open Typedtree
+open BrowseT
+
+let is_node_fun = function
+  | { t_node = Expression { exp_desc = Texp_function _; _ } } -> true
+  | _ -> false
+;;
+
+let is_node_let = function
+  | { t_node = Value_binding _ } -> true
+  | _ -> false
+;;
+
+let is_node_pattern = function
+  | { t_node = Case _ } -> true
+  | _ -> false
+;;
+
+let fun_pred = fun all ->
+  (* For:
+     `let f x y z = ...` jump to f
+     For
+     `let f = fun x -> fun y -> fun z -> ...` jump to f
+     For
+     `List.map l ~f:(fun x -> ...)` jump to fun
+
+     Every fun is immediately followed by pattern in the typed tree.
+     Invariant: head is a fun.
+  *)
+  let rec normalize_fun = function
+    (* fun pat fun something *)
+    | node1 :: node2 :: node3 :: tail when is_node_fun node3 ->
+      assert (is_node_fun node1);
+      assert (is_node_pattern node2);
+      normalize_fun (node3 :: tail)
+    (* fun let something *)
+    | node1 :: node2 :: tail when is_node_let node2 ->
+      assert (is_node_fun node1);
+      node2
+    | node :: tail ->
+      assert (is_node_fun node);
+      node
+    | _ ->
+      assert false
+  in
+  match all with
+  | node :: tail when is_node_fun node -> Some (normalize_fun all)
+  | _ -> None
+;;
+
+let let_pred = function
+  | node :: tail when is_node_let node -> Some node
+  | _ -> None
+;;
+
+let module_pred = function
+  | ({ t_node = Module_binding _} as node) :: tail -> Some node
+  | _ -> None
+;;
+
+let match_pred = function
+  | ({ t_node = Expression { exp_desc = Texp_match _}} as node) :: tail -> Some node
+  | _ -> None
+;;
+
+let rec find_map ~f = function
+  | [] -> None
+  | head :: tail ->
+    match f head with
+    | Some v -> Some v
+    | None -> find_map tail ~f
+;;
+
+exception No_matching_target
+exception No_predicate of string
+
+(* Returns first node on the list matching a predicate *)
+let rec find_node preds nodes =
+  match nodes with
+  | [] -> raise No_matching_target
+  | node :: tail ->
+    match find_map preds ~f:(fun pred -> pred nodes) with
+    | Some node -> node
+    | None -> find_node preds tail
+;;
+
+(* Skip all nodes that won't advance cursor's position *)
+let rec skip_non_moving pos = function
+  | (node :: tail) as all ->
+    let loc_start = node.t_loc.Location.loc_start in
+    if pos.Lexing.pos_lnum = loc_start.Lexing.pos_lnum then
+      skip_non_moving pos tail
+    else
+      all
+  | [] -> []
+;;
+
+let get typed_tree pos target =
+  let roots = Browse.of_typer_contents typed_tree in
+  let enclosings = Browse.enclosing pos roots in
+
+  let all_preds = [
+    "fun", fun_pred;
+    "let", let_pred;
+    "module", module_pred;
+    "match", match_pred;
+  ] in
+  let targets = Str.split (Str.regexp " ") target in
+  try
+    let preds =
+      List.map targets ~f:(fun target ->
+        match List.find_some all_preds ~f:(fun (name, _) -> name = target) with
+        | Some (name, f) -> f
+        | None -> raise (No_predicate target)
+      )
+    in
+    if String.length target = 0 then
+      `Error "Specify target"
+    else begin
+      let nodes = skip_non_moving pos enclosings in
+      let node = find_node preds nodes in
+      `Found node.t_loc.Location.loc_start
+    end
+  with
+  | No_predicate target ->
+    `Error ("No predicate for " ^ target)
+  | No_matching_target ->
+    `Error "No matching target"
+

--- a/src/analysis/jump.mli
+++ b/src/analysis/jump.mli
@@ -1,0 +1,4 @@
+val get :
+  (Merlin_typer.content * 'a) list ->
+  Std.Lexing.position ->
+  string -> [> `Error of string | `Found of Lexing.position ]

--- a/src/frontend/IO.ml
+++ b/src/frontend/IO.ml
@@ -315,6 +315,8 @@ module Protocol_io = struct
       Request (Locate (None, ml_or_mli choice, mandatory_position pos))
     | (`String "locate" :: `String path :: `String choice :: pos) ->
       Request (Locate (Some path, ml_or_mli choice, mandatory_position pos))
+    | (`String "jump" :: `String target :: pos) ->
+      Request (Jump (target, mandatory_position pos))
     | [`String "outline"] ->
       Request Outline
     | [`String "drop"] ->
@@ -468,6 +470,13 @@ module Protocol_io = struct
             `Assoc ["pos", Lexing.json_of_position pos]
           | `Found (Some file,pos) ->
             `Assoc ["file",`String file; "pos", Lexing.json_of_position pos]
+          end
+        | Jump _, resp ->
+          begin match resp with
+          | `Error str ->
+            `String str
+          | `Found pos ->
+            `Assoc ["pos", Lexing.json_of_position pos]
           end
         | Case_analysis _, ({ Location. loc_start ; loc_end }, str) ->
           let assoc =

--- a/src/frontend/command.ml
+++ b/src/frontend/command.ml
@@ -463,6 +463,11 @@ let dispatch (state : state) =
     | otherwise -> otherwise
     end
 
+  | (Jump (target, pos) : a request) ->
+    with_typer state @@ fun typer ->
+    let typed_tree = Typer.contents typer in
+    Jump.get typed_tree pos target
+
   | (Case_analysis ({ Location. loc_start ; loc_end } as loc) : a request) ->
     with_typer state @@ fun typer ->
     let env = Typer.env typer in

--- a/src/frontend/protocol.mli
+++ b/src/frontend/protocol.mli
@@ -115,6 +115,11 @@ type _ request =
        | `Not_found of string * string option
        | `At_origin
        ] request
+  | Jump
+    : string * position
+    -> [ `Found of Lexing.position
+       | `Error of string
+       ] request
   | Case_analysis
     : Location.t -> (Location.t * string) request
   | Outline

--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -288,6 +288,21 @@ def command_locate(path, line, col):
     except MerlinExc as e:
         try_print_error(e)
 
+def command_jump(target, line, col):
+    try:
+        pos_or_err = command("jump", target, "at", {'line': line, 'col': col})
+        if not isinstance(pos_or_err, dict):
+            print(pos_or_err)
+        else:
+            l = pos_or_err['pos']['line']
+            c = pos_or_err['pos']['col']
+            # save the current position in the jump list
+            vim.command("normal! m'")
+            # TODO: move the cursor using vimscript, so we can :keepjumps?
+            vim.current.window.cursor = (l, c)
+    except MerlinExc as e:
+        try_print_error(e)
+
 def command_occurrences(line, col):
     try:
         lst_or_err = command("occurrences", "ident", "at", {'line':line, 'col':col})
@@ -468,6 +483,15 @@ def vim_locate_at_cursor(path):
 
 def vim_locate_under_cursor():
     vim_locate_at_cursor(None)
+
+# Jump
+def vim_jump_to(target):
+    line, col = vim.current.window.cursor
+    sync_full_buffer()
+    command_jump(target, line, col)
+
+def vim_jump_default():
+  vim_jump_to("fun let module match")
 
 # Document
 def vim_document_at_cursor(path):

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -346,6 +346,16 @@ function! merlin#Locate(...)
   endif
 endfunction
 
+function! merlin#Jump(...)
+  if (a:0 > 1)
+    echoerr "Jump: too many arguments (expected 0 or 1)"
+  elseif (a:0 == 0) || (a:1 == "")
+    py merlin.vim_jump_default()
+  else
+    py merlin.vim_jump_to(vim.eval("a:1"))
+  endif
+endfunction
+
 function! merlin#Document(...)
   if (a:0 > 1)
     echoerr "Document: to many arguments (expected 0 or 1)"
@@ -518,6 +528,9 @@ function! merlin#Register()
   if !exists('g:merlin_disable_default_keybindings') || !g:merlin_disable_default_keybindings
     nmap <silent><buffer> gd  :MerlinLocate<return>
   endif
+
+  """ Jump  ------------------------------------------------------------------
+  command! -buffer -complete=customlist,merlin#ExpandPrefix -nargs=? MerlinJump call merlin#Jump(<q-args>)
 
   """ Document  ----------------------------------------------------------------
   command! -buffer -complete=customlist,merlin#ExpandPrefix -nargs=? MerlinDocument call merlin#Document(<q-args>)


### PR DESCRIPTION
This pull request implements a jump command that lets you quickly move to the logical parent nodes in your code.  It is very useful to quickly check the function you're in or even more useful to check the module you're in. One can also jump to let binding and match statement.

It is somehow related to #414.

I'm pretty sure that using `<localleader>j` in vim is a bad idea but I left it for testing. I'll wait for your suggestion.

I imagine people may want different keybinding for different sub commands. Because you can do `:MerlinJump target` where target is a subset of `fun,let,module,match`. For example @bmillwood was interested in just using `:MerlinJump module` and not really `:MerlinJump fun`. So we should make it easy to customize (or maybe just more detailed documentation would be enough for all vim/emacs magicians).