### PR TITLE
[Merlin] Add support for SUFFIX flags.

### DIFF
--- a/src/analysis/track_definition.ml
+++ b/src/analysis/track_definition.ml
@@ -184,10 +184,35 @@ module Utils = struct
     | Longident.Lident _ -> false
     | _ -> true
 
+  let split_extension file =
+    let dirname = Filename.dirname file in
+    (* First grab basename to guard against directories with dots *)
+    let basename = Filename.basename file in
+    try
+      let last_dot_pos = String.rindex basename '.' in
+      let ext_name = String.sub basename last_dot_pos (String.length basename - last_dot_pos) in
+      let base_without_ext = String.sub basename 0 last_dot_pos in
+      let without_ext = Filename.concat dirname base_without_ext in
+      (without_ext, Some ext_name)
+    with Not_found -> (file, None)
+
+
+  let synonym_extension file (implAlias, intfAlias) =
+    match split_extension file with
+      | (without_ext, None) -> without_ext
+      | (without_ext, Some ext) ->
+        if ext = ".ml" then
+          without_ext ^ implAlias
+        else (
+          if ext = ".mli" then
+            without_ext ^ intfAlias
+          else
+            file
+        )
+
   let file_path_to_mod_name f =
     let pref = Misc.chop_extensions f in
     String.capitalize (Filename.basename pref)
-
 
   (* Reuse the code of [Misc.find_in_path_uncap] but returns all the files
      matching, instead of the first one.
@@ -220,7 +245,7 @@ module Utils = struct
     in
     List.map files ~f:Misc.canonicalize_filename
 
-  let find_all_matches ?(with_fallback=false) file =
+  let find_all_matches ~project ?(with_fallback=false) file =
     let fname = Misc.chop_extension_if_any (File.name file) ^ (File.ext file) in
     let fallback =
       if not with_fallback then "" else
@@ -230,10 +255,18 @@ module Utils = struct
       | _ -> assert false
     in
     let path  = Fluid.get sources_path in
-    let files = find_all_in_path_uncap ~fallback path fname in
+
+    let filesList =
+      List.map (fun synonym_pair -> (
+          let fallback = synonym_extension fallback synonym_pair in
+          let fname = synonym_extension fname synonym_pair in
+          find_all_in_path_uncap ~fallback path fname
+        )) (Merlin_lib.Project.suffixes project)
+    in
+    let files = List.concat filesList in
     List.uniq files ~cmp:String.compare
 
-  let find_file_with_path ?(with_fallback=false) file path =
+  let find_file_with_path ~project ?(with_fallback=false) file path =
     let fname = Misc.chop_extension_if_any (File.name file) ^ (File.ext file) in
     let fallback =
       if not with_fallback then "" else
@@ -243,12 +276,30 @@ module Utils = struct
       | File.CMT f  -> Misc.chop_extension_if_any f ^ ".cmti"
       | File.CMTI f -> Misc.chop_extension_if_any f ^ ".cmt"
     in
-    try Misc.find_in_path_uncap ~fallback path fname
-    with Not_found ->
-      raise (File.Not_found file)
+    let rec attempt_search synonyms =
+      match synonyms with
+        | [] -> raise Not_found
+        | [synonym_pair] ->
+          (* Upon trying the final [synonym_pair], search failure should raise *)
+          let fallback = synonym_extension fallback synonym_pair in
+          let fname = synonym_extension fname synonym_pair in
+          (
+            try Misc.find_in_path_uncap ~fallback path fname with
+                Not_found -> raise (File.Not_found file)
+          )
+        | synonym_pair :: ((rest1 :: rest2) as rest_synonyms) ->
+          (* If cannot find match, continue searching through [rest_synonyms] *)
+          let fallback = synonym_extension fallback synonym_pair in
+          let fname = synonym_extension fname synonym_pair in
+          (
+            try Misc.find_in_path_uncap ~fallback path fname with
+                Not_found -> attempt_search rest_synonyms
+          )
+    in
+    attempt_search (Merlin_lib.Project.suffixes project)
 
-  let find_file ?with_fallback file =
-    find_file_with_path ?with_fallback file @@
+  let find_file ~project ?with_fallback file =
+    find_file_with_path ~project ?with_fallback file @@
         match file with
         | File.ML  _ | File.MLI _  -> Fluid.get sources_path
         | File.CMT _ | File.CMTI _ -> Fluid.get loadpath
@@ -257,7 +308,7 @@ end
 type context = Type | Expr | Patt | Unknown
 exception Context_mismatch
 
-let rec locate ?pos path trie =
+let rec locate ~project ?pos path trie =
   match Typedtrie.find ?before:pos trie path with
   | Typedtrie.Found (loc, doc_opt) -> Some (loc, doc_opt)
   | Typedtrie.Resolves_to (new_path, fallback) ->
@@ -265,7 +316,7 @@ let rec locate ?pos path trie =
     | (_, `Mod) :: _ ->
       debug_log "resolves to %s" (Typedtrie.path_to_string new_path) ;
       Fallback.setopt fallback ;
-      from_path new_path
+      from_path ~project new_path
     | _ ->
       debug_log "new path (%s) is not a real path. fallbacking..."
         (Typedtrie.path_to_string new_path) ;
@@ -276,16 +327,16 @@ let rec locate ?pos path trie =
     debug_log "alias of %s" (Typedtrie.path_to_string new_path) ;
     (* TODO: maybe give the option to NOT follow module aliases? *)
     Fallback.set loc;
-    from_path new_path
+    from_path ~project new_path
 
-and browse_cmts ~root modules =
+and browse_cmts ~project ~root modules =
   let open Cmt_format in
   let cached = Cmt_cache.read root in
   info_log "inspecting %s" root ;
   File_switching.move_to ?digest:cached.Cmt_cache.cmt_infos.cmt_source_digest root ;
   if cached.Cmt_cache.location_trie <> String.Map.empty then
     let () = debug_log "cmt already cached" in
-    locate modules cached.Cmt_cache.location_trie
+    locate ~project modules cached.Cmt_cache.location_trie
   else
     match
       match cached.Cmt_cache.cmt_infos.cmt_annots with
@@ -309,7 +360,7 @@ and browse_cmts ~root modules =
       | _ ->
         let trie = Typedtrie.of_browses [BrowseT.of_node node] in
         cached.Cmt_cache.location_trie <- trie ;
-        locate modules trie
+        locate ~project modules trie
       end
     | `Pack files ->
       begin match modules with
@@ -318,7 +369,7 @@ and browse_cmts ~root modules =
         Logger.debug section ~title:"loadpath" "Saw packed module => erasing loadpath" ;
         let new_path = cached.Cmt_cache.cmt_infos.cmt_loadpath in
         erase_loadpath ~cwd:(Filename.dirname root) ~new_path (fun () ->
-          from_path modules
+          from_path ~project modules
         )
       | _ -> None
       end
@@ -335,7 +386,7 @@ and browse_cmts ~root modules =
       Assuming we are in such a situation, if we do not find something in our
       "erased" loadpath, it could mean that we are looking for a persistent
       unit, and that's why we restore the initial loadpath. *)
-and from_path path =
+and from_path ~project path =
   debug_log "from_path '%s'" (Typedtrie.path_to_string path) ;
   match path with
   | [ fname, `Mod ] ->
@@ -347,12 +398,12 @@ and from_path path =
       Some (loc, None)
     in
     begin try
-      let cmt_file = Utils.find_file ~with_fallback:true (Preferences.cmt fname) in
+      let cmt_file = Utils.find_file ~project ~with_fallback:true (Preferences.cmt fname) in
       save_digest_and_return cmt_file
     with File.Not_found (File.CMT fname | File.CMTI fname) ->
       restore_loadpath (fun () ->
         try
-          let cmt_file = Utils.find_file ~with_fallback:true (Preferences.cmt fname) in
+          let cmt_file = Utils.find_file ~project ~with_fallback:true (Preferences.cmt fname) in
           save_digest_and_return cmt_file
         with File.Not_found (File.CMT fname | File.CMTI fname) ->
           (* In that special case, we haven't managed to find any cmt. But we
@@ -368,13 +419,13 @@ and from_path path =
     end
   | (fname, `Mod) :: modules ->
     begin try
-      let cmt_file = Utils.find_file ~with_fallback:true (Preferences.cmt fname) in
-      browse_cmts ~root:cmt_file modules
+      let cmt_file = Utils.find_file ~project ~with_fallback:true (Preferences.cmt fname) in
+      browse_cmts ~project ~root:cmt_file modules
     with File.Not_found (File.CMT fname | File.CMTI fname) as exn ->
       restore_loadpath (fun () ->
         try
-          let cmt_file = Utils.find_file ~with_fallback:true (Preferences.cmt fname) in
-          browse_cmts ~root:cmt_file modules
+          let cmt_file = Utils.find_file ~project ~with_fallback:true (Preferences.cmt fname) in
+          browse_cmts ~project ~root:cmt_file modules
         with File.Not_found (File.CMT fname | File.CMTI fname) ->
           info_log "failed to locate the cmt[i] of '%s'" fname ;
           raise exn
@@ -393,7 +444,7 @@ let path_and_loc_from_label desc env =
 exception Not_in_env
 exception Multiple_matches of string list
 
-let find_source loc =
+let find_source ~project loc =
   let fname = loc.Location.loc_start.Lexing.pos_fname in
   let with_fallback = loc.Location.loc_ghost in
   let mod_name = Utils.file_path_to_mod_name fname in
@@ -407,13 +458,13 @@ let find_source loc =
   | None -> (* We have not moved, we don't want to return a filename *) None
   | Some s ->
     let dir = Filename.dirname s in
-    match Utils.find_all_matches ~with_fallback file with
+    match Utils.find_all_matches ~project ~with_fallback file with
     | [] ->
       debug_log "failed to find \"%s\" in source path (fallback = %b)"
           filename with_fallback ;
       debug_log "(for reference: fname = %S)" fname;
       debug_log "looking in '%s'" dir ;
-      Some (Utils.find_file_with_path ~with_fallback file [dir])
+      Some (Utils.find_file_with_path ~project ~with_fallback file [dir])
     | [ x ] -> Some x
     | files ->
       info_log "multiple files named %s exist in the source path..." filename;
@@ -476,8 +527,8 @@ let find_source loc =
    [find_source] doesn't like the "-o" option of the compiler. This hack handles
    Jane Street specific use case where "-o" is used to prefix a unit name by the
    name of the library which contains it. *)
-let find_source loc =
-  try find_source loc
+let find_source ~project loc =
+  try find_source ~project loc
   with exn ->
     let fname = loc.Location.loc_start.Lexing.pos_fname in
     try
@@ -488,7 +539,7 @@ let find_source loc =
         let lstart = { loc.Location.loc_start with Lexing.pos_fname = fname } in
         { loc with Location.loc_start = lstart }
       in
-      find_source loc
+      find_source ~project loc
     with _ -> raise exn
 
 let recover ident =
@@ -545,7 +596,7 @@ let lookup ctxt ident env =
   with Found x ->
     x
 
-let locate ~ml_or_mli ~path ~lazy_trie ~pos ~str_ident loc =
+let locate ~project ~ml_or_mli ~path ~lazy_trie ~pos ~str_ident loc =
   File_switching.reset ();
   Fallback.reset ();
   Preferences.set ml_or_mli;
@@ -557,7 +608,7 @@ let locate ~ml_or_mli ~path ~lazy_trie ~pos ~str_ident loc =
           (Typedtrie.path_to_string path)
       in
       let trie = Lazy.force lazy_trie in
-      match locate ~pos path trie with
+      match locate ~project ~pos path trie with
       | None when Fallback.is_set () -> recover str_ident
       | None -> `Not_found (str_ident, File_switching.where_am_i ())
       | Some (loc, doc) -> `Found (loc, doc)
@@ -567,14 +618,14 @@ let locate ~ml_or_mli ~path ~lazy_trie ~pos ~str_ident loc =
   | File.Not_found path -> File.explain_not_found str_ident path
 
 (* Only used to retrieve documentation *)
-let from_completion_entry ~lazy_trie ~pos (namespace, path, loc) =
+let from_completion_entry ~project ~lazy_trie ~pos (namespace, path, loc) =
   let path_lst  = Path.to_string_list path in
   let str_ident = String.concat ~sep:"." path_lst in
   let tagged_path = tag namespace path in
-  locate ~ml_or_mli:`MLI ~path:tagged_path ~pos ~str_ident loc
+  locate ~project ~ml_or_mli:`MLI ~path:tagged_path ~pos ~str_ident loc
     ~lazy_trie
 
-let from_longident ~env ~lazy_trie ~pos ctxt ml_or_mli lid =
+let from_longident ~project ~env ~lazy_trie ~pos ctxt ml_or_mli lid =
   let ident, is_label = Longident.keep_suffix lid in
   let str_ident = String.concat ~sep:"." (Longident.flatten ident) in
   try
@@ -586,7 +637,7 @@ let from_longident ~env ~lazy_trie ~pos ctxt ml_or_mli lid =
       (* TODO: Use [`Labels] here *)
       tag `Type path, loc
     in
-    locate ~ml_or_mli ~path:tagged_path ~lazy_trie ~pos ~str_ident loc
+    locate ~project ~ml_or_mli ~path:tagged_path ~lazy_trie ~pos ~str_ident loc
   with
   | Not_found -> `Not_found (str_ident, File_switching.where_am_i ())
   | Not_in_env -> `Not_in_env str_ident
@@ -666,12 +717,12 @@ let from_string ~project ~env ~local_defs ~pos switch path =
     Fluid.let' cfg_cmt_path (Project.cmt_path project) @@ fun () ->
     Fluid.let' loadpath     (Project.cmt_path project) @@ fun () ->
     match
-      from_longident ~pos ~env ~lazy_trie ctxt switch lid
+      from_longident ~project ~pos ~env ~lazy_trie ctxt switch lid
     with
     | `File_not_found _ | `Not_found _ | `Not_in_env _ as error -> error
     | `Found (loc, _) ->
       try
-        match find_source loc with
+        match find_source ~project loc with
         | None     -> `Found (None, loc.Location.loc_start)
         | Some src -> `Found (Some src, loc.Location.loc_start)
       with
@@ -696,7 +747,7 @@ let get_doc ~project ~env ~local_defs ~comments ~pos source =
   Fluid.let' last_location Location.none @@ fun () ->
   match
     match path with
-    | `Completion_entry entry -> from_completion_entry ~pos ~lazy_trie entry
+    | `Completion_entry entry -> from_completion_entry ~project ~pos ~lazy_trie entry
     | `User_input path ->
       let lid    = Longident.parse path in
       begin match inspect_context browse path pos with
@@ -704,7 +755,7 @@ let get_doc ~project ~env ~local_defs ~comments ~pos source =
         `Found ({ Location. loc_start=pos; loc_end=pos ; loc_ghost=true }, None)
       | Some ctxt ->
         info_log "looking for the doc of '%s'" path ;
-        from_longident ~pos ~env ~lazy_trie ctxt `MLI lid
+        from_longident ~project ~pos ~env ~lazy_trie ctxt `MLI lid
       end
   with
   | `Found (loc, Some doc) ->

--- a/src/kernel/dot_merlin.ml
+++ b/src/kernel/dot_merlin.ml
@@ -41,6 +41,7 @@ type directive = [
   | `FLG of string
   | `STDLIB of string
   | `FINDLIB of string
+  | `SUFFIX of string
 ]
 
 type file = {
@@ -82,6 +83,8 @@ module Cache = File_cache.Make (struct
             tell (`STDLIB (String.drop 7 line))
           else if String.is_prefixed ~by:"FINDLIB " line then
             tell (`FINDLIB (String.drop 8 line))
+          else if String.is_prefixed ~by:"SUFFIX " line then
+            tell (`SUFFIX (String.drop 7 line))
           else if String.is_prefixed ~by:"#" line then
             ()
           else
@@ -137,6 +140,7 @@ type config = {
   packages    : string list;
   flags       : string list list;
   extensions  : string list;
+  suffixes    : (string * string) list;
   stdlib      : string;
   findlib     : string option;
 }
@@ -176,6 +180,7 @@ let empty_config = {
   packages    = [];
   dot_merlins = [];
   extensions  = [];
+  suffixes    = [(".ml", ".mli")];
   flags       = [];
   stdlib      = Config.standard_library;
   findlib     = None;
@@ -189,12 +194,29 @@ let merge c1 c2 = {
   packages    = c1.packages @ c2.packages;
   dot_merlins = c1.dot_merlins @ c2.dot_merlins;
   extensions  = c1.extensions @ c2.extensions;
+  suffixes    = c1.suffixes @ c2.suffixes;
   flags       = c1.flags @ c2.flags;
   stdlib      = if c1.stdlib = empty_config.stdlib then c2.stdlib else c1.stdlib;
   findlib     = if c1.findlib = None then c2.findlib else c1.findlib;
 }
 
 let flg_regexp = Str.regexp "\\([^ \t\r\n']+\\|'[^']*'\\)"
+let white_regexp = Str.regexp "[ \t]+"
+
+(* Parses suffixes pairs that were supplied as whitespace separated pairs
+   designating implementation/interface suffixes. These would be supplied in
+   the .merlin file as:
+
+   SUFFIX .sfx .sfxi   *)
+let parse_suffix str =
+  let trimmed = String.trim str in
+  let split_on_white = Str.split white_regexp trimmed in
+  if List.length split_on_white != 2 then []
+  else
+    let (first, second) = (List.nth split_on_white 0, List.nth split_on_white 1) in
+    if String.get first 0 != '.' || String.get second 0 != '.' then []
+    else [(first, second)]
+
 let rev_split_flags str =
   let rec aux acc str i =
     match try Some (Str.search_forward flg_regexp str i) with Not_found -> None with
@@ -233,6 +255,8 @@ let prepend_config {path; directives} config =
     | `PKG pkgs -> {config with packages = pkgs @ config.packages}
     | `EXT exts ->
       {config with extensions = exts @ config.extensions}
+    | `SUFFIX suffix ->
+      {config with suffixes = (parse_suffix suffix) @ config.suffixes}
     | `FLG flags ->
       let flags = List.rev (rev_split_flags flags) in
       {config with flags = flags :: config.flags}
@@ -252,6 +276,7 @@ let postprocess_config config =
     cmt_path    = clean config.cmt_path;
     packages    = clean config.packages;
     extensions  = clean config.extensions;
+    suffixes    = clean config.suffixes;
     flags       = clean config.flags;
     stdlib      = config.stdlib;
     findlib     = config.findlib;

--- a/src/kernel/dot_merlin.mli
+++ b/src/kernel/dot_merlin.mli
@@ -39,6 +39,7 @@ type config = {
   packages    : string list;
   flags       : string list list;
   extensions  : string list;
+  suffixes    : (string * string) list;
   stdlib      : string;
   findlib     : string option;
 }

--- a/src/kernel/merlin_lib.ml
+++ b/src/kernel/merlin_lib.ml
@@ -72,6 +72,9 @@ module Project : sig
   (* Enabled extensions *)
   val extensions: t -> Extension.set
 
+  (* Suffixes to search for located files with. *)
+  val suffixes:  t -> (string * string) list
+
   (* Lexer keywords for current config *)
   val keywords: t -> Lexer.keywords
 
@@ -94,6 +97,7 @@ end = struct
       warnings       : Warnings.state;
       keywords       : Lexer.keywords;
       extensions     : Extension.set;
+      suffixes       : (string * string) list;
       validity_stamp : bool ref;
 
       source_path    : string list;
@@ -173,7 +177,11 @@ end = struct
              else user_config.stdlib]
           else []
       in
-      let source_path =
+      let clean list = List.rev (List.filter_dup list) in
+      let suffixes =
+          clean (user_config.suffixes @
+          dot_config.suffixes)
+      and source_path =
           user_config.source_path @
           dot_config.source_path @
           pkgpaths
@@ -202,7 +210,7 @@ end = struct
       let config = C.({
           dot_config;
           warnings; flags;
-          extensions; keywords;
+          extensions; suffixes; keywords;
           source_path; cmt_path; build_path;
           dot_failures = dfails0 @ dfails1;
           user_failures = ufails0 @ ufails1;
@@ -275,6 +283,9 @@ end = struct
 
   (* Enabled extensions *)
   let extensions t = (config t).extensions
+
+  (* Suffixes to search for located files with. *)
+  let suffixes t = (config t).suffixes
 
   (* Lexer keywords for current config *)
   let keywords t = (config t).keywords

--- a/vim/merlin/syntax/merlin.vim
+++ b/vim/merlin/syntax/merlin.vim
@@ -3,7 +3,7 @@ if exists("b:current_syntax")
   finish
 endif
 
-syn keyword merlinKeyword S B PKG REC EXT PRJ FLG CMI CMT
+syn keyword merlinKeyword S B SUFFIX PKG REC EXT PRJ FLG CMI CMT
 syn match merlinComment "\v#.*$"
 
 hi link merlinKeyword Keyword


### PR DESCRIPTION
Summary: In the `ocamlc`/`ocamlopt` compiler, there is no restriction on
which file suffixes may be used. To use a file with a non-standard
suffix, you would supply the file as either `-intf` or `-impl` (note,
you would also tell the compiler that a `-impl` file has a corresponding
interface in a particular suffix by specifying `-intf-suffix`). However,
until this diff, merlin only searches for files with the `.ml/.mli`
suffixes. This diff adds support for checking other suffixes when
locating files. Merlin's heuristic will sometimes try appending `.ml` to
the end of a module name, etc - this diff allows you to instruct it to
also try other suffixes. It works great!

Test Plan:

Reviewers:

CC: