### PR TITLE
Add ability to supply custom flags to merlin binary from Vim

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -86,7 +86,7 @@ class MerlinProcess:
                 path = self.path
             else:
                 path = vim.eval("merlin#FindBinary()")
-            cmd = [path,"-ignore-sigint"]
+            cmd = [path,"-ignore-sigint"] + vim.eval('g:merlin_binary_flags')
             if self.env:
                 env = self.env
             else:

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -13,6 +13,10 @@ if !exists('g:merlin_locate_preference')
     let g:merlin_locate_preference = 'ml'
 endif
 
+if !exists('g:merlin_binary_flags')
+    let g:merlin_binary_flags = []
+endif
+
 if !exists("g:merlin_ignore_warnings")
   " strings are ugly, but at least I'm sure it's not converted in some weird
   " value when passing it to python


### PR DESCRIPTION
Allows specifying of merlin binary flags via a global config in Vim.

@yunxing