### PR TITLE
Reverse history

### DIFF
--- a/src/kernel/merlin_lexer.ml
+++ b/src/kernel/merlin_lexer.ml
@@ -214,11 +214,12 @@ let extract_ident = function
 let as_history t pos =
   if t.items = [] then None
   else
-    let h = History.of_list t.items in
+    let h = History.of_list @@ List.rev t.items in
     let h = History.seek_forward ~last:true (function
-        | Triple (_,_,e) -> Lexing.compare_pos pos e <= 0
+        | Triple (_,_,e) -> Lexing.compare_pos e pos <= 0
         | _ -> true
       ) h in
+    let h = History.move 1 h in
     Some h
 
 (* [reconstruct_identifier] is impossible to read at the moment, here is a


### PR DESCRIPTION
The 'items' list generated by Lexer is actually in reversed order. (e.g., 'EOF' is the head of the list). 

However the result of the logic in "reconstruct_identifier" assumes that the history is not reversed. 

This patch reverses the items before feeding it into the constructor of history. 

I've tested it with "Locate" command, it seems more correct now. 

cc @jordwalke 