### PR TITLE
Configure script is bash specific

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 BIN_DIR=/usr/local/bin
 SHARE_DIR=/usr/local/share


### PR DESCRIPTION
The configure scirpt fails when /bin/sh isn't bash. Changed the shebang line to use "/usr/bin/env bash"