### PR TITLE
findlib search path

### DIFF
--- a/src/kernel/dot_merlin.mli
+++ b/src/kernel/dot_merlin.mli
@@ -41,6 +41,7 @@ type config = {
   stdlib      : string;
   findlib     : string option;
   reader      : string list;
+  search      : string list;
 }
 
 type t (* A config + caching information *)


### PR DESCRIPTION
Adding a new directive "SEARCH" to .merlin that sets the findlib search path for the project, overriding any OCAMLPATH variable