### PR TITLE
Implementing the imenu feature for Merlin-Emacs to view code outline 

### DIFF
--- a/emacs/merlin-imenu.el
+++ b/emacs/merlin-imenu.el
@@ -53,6 +53,7 @@
                            (t (concat (visit (cdr xs)) " / " (car xs))))))
     (if (null items) "" (visit items))))
 
+;; go to the location of the item
 (defun merlin-imenu--goto-item (line col item)
   (save-excursion
     ;; go to line
@@ -66,6 +67,7 @@
     ;; return the marker
     (point)))
 
+;; the main indexing function
 (defun merlin-imenu-create-index ()
   "Set imenu function"
   (merlin/sync)
@@ -148,6 +150,7 @@
               (push (cons "Misc" misc-list) index))
             index))))))
 
+;; enable Merlin to use the merlin-imenu module
 (defun merlin-use-merlin-imenu ()
   "Merlin: use the custom imenu feature from Merlin"
   (interactive)
@@ -168,6 +171,7 @@
   ;; (imenu--menubar-select imenu--rescan-item)
   (message "Merlin: merlin-imenu is selected, rescanning buffer..."))
 
+;; enable Merlin to use the default tuareg-imenu module
 (defun merlin-use-tuarge-imenu ()
   "Merlin: use the default imenu feature from Tuareg"
   (interactive)

--- a/emacs/merlin-imenu.el
+++ b/emacs/merlin-imenu.el
@@ -73,8 +73,9 @@
          (outline (merlin/send-command `outline)))
     (when outline
       ;; (message outline)
-      (let ((module-list) (value-list) (type-list) (class-list)
-            (exn-list) (misc-list))
+      (let ((module-list) (value-list) (type-list)
+            (class-list) (exception-list) (constructor-list)
+            (label-list) (misc-list))
         (cl-labels
             ((visit-one (prefix x)
                         (let* ((fstart (nth 1 x))
@@ -84,33 +85,44 @@
                                (start-col (cdr (nth 3 fstart)))
                                (name (cdr fname))
                                (kind (cdr fkind))
-                               (children (nth 5 x)))
-                          (if (null (cdr children))
-                              (let* ((item (merlin-imenu--list-to-string
-                                            (cons name prefix))))
-                                (setq marker (make-marker))
-                                (setq start-pos
-                                      (merlin-imenu--goto-item start-line
-                                                               start-col
-                                                               name))
-                                (set-marker marker start-pos)
-                                (setq fitem (cons item marker))
-                                ;; (message "name %s : kind %s" name kind)
-                                (cond
-                                 ((string= (string-trim kind) "Value")
-                                  (setq value-list (cons fitem value-list)))
-                                 ((string= (string-trim kind) "Type")
-                                  (setq type-list (cons fitem type-list)))
-                                 ((string= (string-trim kind) "Class")
-                                  (setq class-list (cons fitem class-list)))
-                                 ((string= (string-trim kind) "Module")
-                                  (setq module-list (cons fitem module-list)))
-                                 ((string= (string-trim kind) "Exn")
-                                  (setq exn-list (cons fitem exn-list)))
-                                 (t
-                                  (setq misc-list (cons fitem misc-list)))))
-                            (visit-many (cons name prefix) (cdr children))
-                            )))
+                               (children (nth 5 x))
+                               (item (merlin-imenu--list-to-string
+                                      (cons name prefix))))
+                          (progn
+                            (setq marker (make-marker))
+                            (setq start-pos
+                                  (merlin-imenu--goto-item start-line
+                                                           start-col
+                                                           name))
+                            (set-marker marker start-pos)
+                            (setq fitem (cons item marker))
+                            (message "name %s : kind %s" name kind)
+                            (cond
+                             ((string= (string-trim kind) "Value")
+                              (setq value-list
+                                    (cons fitem value-list)))
+                             ((string= (string-trim kind) "Type")
+                              (setq type-list
+                                    (cons fitem type-list)))
+                             ((string= (string-trim kind) "Class")
+                              (setq class-list
+                                    (cons fitem class-list)))
+                             ((string= (string-trim kind) "Module")
+                              (setq module-list
+                                    (cons fitem module-list)))
+                             ((string= (string-trim kind) "Exn")
+                              (setq exception-list
+                                    (cons fitem exception-list)))
+                             ((string= (string-trim kind) "Constructor")
+                              (setq constructor-list
+                                    (cons fitem constructor-list)))
+                             ((string= (string-trim kind) "Label")
+                              (setq label-list
+                                    (cons fitem label-list)))
+                             (t (setq misc-list (cons fitem misc-list))))
+                            (if (not (null (cdr children)))
+                                (visit-many (cons name prefix)
+                                            (cdr children))))))
              (visit-many (prefix xs)
                          (when (not (null xs))
                            (visit-one prefix (car xs))
@@ -118,14 +130,23 @@
           (visit-many '() outline)
           ;; (merlin-imenu--print-all-values value-list)
           (let ((index ()))
-            (when module-list (push (cons "Module" module-list) index))
-            (when type-list (push (cons "Type" type-list) index))
-            (when class-list (push (cons "Class" class-list) index))
-            (when value-list (push (cons "Value" value-list) index))
-            (when exn-list (push (cons "Exn" exn-list) index))
-            (when misc-list (push (cons "Misc" misc-list) index))
-            index)
-          )))))
+            (when module-list
+              (push (cons "Module" module-list) index))
+            (when exception-list
+              (push (cons "Exception" exception-list) index))
+            (when label-list
+              (push (cons "Label" label-list) index))
+            (when constructor-list
+              (push (cons "Constructor" constructor-list) index))
+            (when type-list
+              (push (cons "Type" type-list) index))
+            (when class-list
+              (push (cons "Class" class-list) index))
+            (when value-list
+              (push (cons "Value" value-list) index))
+            (when misc-list
+              (push (cons "Misc" misc-list) index))
+            index))))))
 
 (defun merlin-use-merlin-imenu ()
   "Merlin: use the custom imenu feature from Merlin"
@@ -151,7 +172,7 @@
   ;; (imenu--menubar-select imenu--rescan-item)
   (message "Merlin: tuareg-imenu is selected, rescanning buffer..."))
 
-;; (message "Eval Merlin-IMenu")  ;; for debugging
+(message "Eval Merlin-IMenu")  ;; for debugging
 
 (provide 'merlin-imenu)
 ;;; merlin-imenu.el ends here

--- a/emacs/merlin-imenu.el
+++ b/emacs/merlin-imenu.el
@@ -1,0 +1,133 @@
+;;; merlin-imenu.el --- Merlin and imenu integration.   -*- coding: utf-8 -*-
+;; Licensed under the MIT license.
+
+;; Author: Ta Quang Trung <taquangtrungvn(_)yahoo.com>
+;; Created: 10 July 2016
+;; Version: 0.1
+;; Keywords: ocaml languages
+;; URL: 
+
+(require 'imenu)
+(require 'tuareg)
+
+
+(defun merlin-imenu--list-to-string (items)
+  (cl-labels ((visit (xs)
+                     (cond ((null xs) "")
+                           ((null (cdr xs)) (car xs))
+                           (t (concat (visit (cdr xs)) " / " (car xs))))))
+    (if (null items) "" (visit items))))
+
+(defun merlin-imenu--print-item (item)
+  (cl-labels ((visit (xs)
+                     (cond ((null xs) "")
+                           ((null (cdr xs)) (car (car xs)))
+                           (t (concat (visit (cdr xs)) " / " (car (car xs)))))))
+    (if (null item) "" (visit item))))
+
+(defun merlin-imenu--print-all-values (items)
+  (cl-labels ((visit (xs)
+                  (when (not (null xs))
+                    (message (concat "Value: " (car (car xs))))
+                    (visit (cdr xs))
+                    )))
+    (visit items)))
+
+(defun merlin-imenu--print-all-modules (items)
+  (cl-labels ((visit (xs)
+                  (when (not (null xs))
+                    (message (concat "Module: " (car (car xs))))
+                    (visit (cdr xs))
+                    )))
+    (visit items)))
+
+(defun merlin-imenu-create-index ()
+  "Set imenu function"
+  (interactive)
+  (merlin/sync)
+  (let* ((pos (merlin/unmake-point (point)))
+         (outline (merlin/send-command `outline)))
+    (when outline
+      ;; (message outline)
+      (let ((module-list) (value-list) (type-list) (class-list) (misc-list))
+        (cl-labels
+            ((visit-one (prefix x)
+                        (let* ((fstart (nth 1 x))
+                               (fend (nth 2 x))
+                               (fname (nth 3 x))
+                               (fkind (nth 4 x))
+                               (start-line (cdr (nth 2 fstart)))
+                               (start-col (cdr (nth 3 fstart)))
+                               (end-line (cdr (nth 2 fend)))
+                               (end-col (cdr (nth 3 fend)))
+                               (name (cdr fname))
+                               (kind (cdr fkind))
+                               (children (nth 5 x)))
+                          (message "start line %d" start-line)
+                          (message "start col %d" start-col)
+                          (message "end line %d" end-line)
+                          (message "end col %d" end-col)
+                          ;; (message (concat "start line -- " (nth 1 fstart)))
+                          (if (null (cdr children))
+                              (let* ((item (merlin-imenu--list-to-string
+                                            (cons name prefix)))
+                                     (fitem (cons item (point-marker))))
+                                ;; (message (concat "Item: " item))
+                                (cond
+                                 ((string= (string-trim kind) "Value")
+                                  (setq value-list (cons fitem value-list)))
+                                 ((string= (string-trim kind) "Type")
+                                  (setq type-list (cons fitem type-list)))
+                                 ((string= (string-trim kind) "Class")
+                                  (setq class-list (cons fitem class-list)))
+                                 ((string= (string-trim kind) "Module")
+                                  (setq module-list (cons fitem module-list)))
+                                 (t
+                                  (setq misc-list (cons fitem misc-list)))))
+                            (visit-many (cons name prefix) (cdr children))
+                            )))
+             (visit-many (prefix xs)
+                         (when (not (null xs))
+                           (visit-one prefix (car xs))
+                           (visit-many prefix (cdr xs)))))
+          (visit-many '() outline)
+          (merlin-imenu--print-all-values value-list)
+          ;; (merlin-imenu--print-all-modules module-list)
+          (let ((index ()))
+            (when module-list (push (cons "Module" module-list) index))
+            (when type-list   (push (cons "Type" type-list) index))
+            (when class-list  (push (cons "Class" class-list) index))
+            (when value-list  (push (cons "Value" value-list) index))
+            (when misc-list   (push (cons "Misc" misc-list) index))
+            index)
+          )))))
+
+(defun merlin-use-merlin-imenu ()
+  "Merlin: use the custom imenu feature from Merlin"
+  (interactive)
+  ;; change the index function
+  (setq imenu-create-index-function 
+        'merlin-imenu-create-index)
+  ;; clear the index list of imenu to force a rescan
+  (imenu--cleanup)
+  (setq imenu--index-alist nil)
+  ;; (imenu--menubar-select imenu--rescan-item)
+  (message "Merlin1: merlin-imenu is selected, rescanning buffer..."))
+
+(defun merlin-use-tuarge-imenu ()
+  "Merlin: use the default imenu feature from Tuareg"
+  (interactive)
+  ;; change the index function
+  (setq imenu-create-index-function 
+        'tuareg-imenu-create-index)
+  ;; clear the index list of imenu to force a rescan
+  (imenu--cleanup)
+  (setq imenu--index-alist nil)
+  ;; (imenu--menubar-select imenu--rescan-item)
+  (message "Merlin: tuareg-imenu is selected, rescanning buffer...")
+  )
+
+(message "Eval Merlin-IMenu")
+
+(provide 'merlin-imenu)
+;;; merlin.el ends here

--- a/emacs/merlin-imenu.el
+++ b/emacs/merlin-imenu.el
@@ -96,7 +96,7 @@
                                                            name))
                             (set-marker marker start-pos)
                             (setq fitem (cons item marker))
-                            (message "name %s : kind %s" name kind)
+                            ;; (message "name %s : kind %s" name kind)
                             (cond
                              ((string= (string-trim kind) "Value")
                               (setq value-list
@@ -152,8 +152,16 @@
   "Merlin: use the custom imenu feature from Merlin"
   (interactive)
   ;; change the index function
-  (setq imenu-create-index-function 
-        'merlin-imenu-create-index)
+  (setq imenu-create-index-function 'merlin-imenu-create-index)
+  ;;;;; For testing: comment out the above line and
+  ;;;;; uncomment the below function to print time spent by merlin-imenu
+  ;; (setq imenu-create-index-function
+  ;;       '(lambda ()
+  ;;          (setq time (current-time))
+  ;;          (setq res (merlin-imenu-create-index))
+  ;;          (message "** Time spent by Merlin-Imenu: %0.6fs"
+  ;;                   (float-time (time-since time)))
+  ;;          res))
   ;; clear the index list of imenu to force a rescan
   (imenu--cleanup)
   (setq imenu--index-alist nil)
@@ -164,15 +172,23 @@
   "Merlin: use the default imenu feature from Tuareg"
   (interactive)
   ;; change the index function
-  (setq imenu-create-index-function 
-        'tuareg-imenu-create-index)
+  (setq imenu-create-index-function 'tuareg-imenu-create-index)
+  ;;;;; For testing: comment out the above line and
+  ;;;;; uncomment the below function to print time spent by tuareg-imenu
+  ;; (setq imenu-create-index-function
+  ;;       '(lambda ()
+  ;;          (setq time (current-time))
+  ;;          (setq res (tuareg-imenu-create-index))
+  ;;          (message "** Time spent by Tuareg-Imenu: %0.6fs"
+  ;;                   (float-time (time-since time)))
+  ;;          res))
   ;; clear the index list of imenu to force a rescan
   (imenu--cleanup)
   (setq imenu--index-alist nil)
   ;; (imenu--menubar-select imenu--rescan-item)
   (message "Merlin: tuareg-imenu is selected, rescanning buffer..."))
 
-(message "Eval Merlin-IMenu")  ;; for debugging
+;; (message "Eval Merlin-IMenu")  ;; for debugging
 
 (provide 'merlin-imenu)
 ;;; merlin-imenu.el ends here

--- a/emacs/merlin-imenu.el
+++ b/emacs/merlin-imenu.el
@@ -73,7 +73,8 @@
          (outline (merlin/send-command `outline)))
     (when outline
       ;; (message outline)
-      (let ((module-list) (value-list) (type-list) (class-list) (misc-list))
+      (let ((module-list) (value-list) (type-list) (class-list)
+            (exn-list) (misc-list))
         (cl-labels
             ((visit-one (prefix x)
                         (let* ((fstart (nth 1 x))
@@ -94,6 +95,7 @@
                                                                name))
                                 (set-marker marker start-pos)
                                 (setq fitem (cons item marker))
+                                ;; (message "name %s : kind %s" name kind)
                                 (cond
                                  ((string= (string-trim kind) "Value")
                                   (setq value-list (cons fitem value-list)))
@@ -103,6 +105,8 @@
                                   (setq class-list (cons fitem class-list)))
                                  ((string= (string-trim kind) "Module")
                                   (setq module-list (cons fitem module-list)))
+                                 ((string= (string-trim kind) "Exn")
+                                  (setq exn-list (cons fitem exn-list)))
                                  (t
                                   (setq misc-list (cons fitem misc-list)))))
                             (visit-many (cons name prefix) (cdr children))
@@ -115,10 +119,11 @@
           ;; (merlin-imenu--print-all-values value-list)
           (let ((index ()))
             (when module-list (push (cons "Module" module-list) index))
-            (when type-list   (push (cons "Type" type-list) index))
-            (when class-list  (push (cons "Class" class-list) index))
-            (when value-list  (push (cons "Value" value-list) index))
-            (when misc-list   (push (cons "Misc" misc-list) index))
+            (when type-list (push (cons "Type" type-list) index))
+            (when class-list (push (cons "Class" class-list) index))
+            (when value-list (push (cons "Value" value-list) index))
+            (when exn-list (push (cons "Exn" exn-list) index))
+            (when misc-list (push (cons "Misc" misc-list) index))
             index)
           )))))
 

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1191,8 +1191,12 @@ prefix of `bar' is `'."
 If QUIET is non nil, then an overlay and the merlin types can be used."
   (if (not type)
       (unless quiet (message "<no information>"))
-    (let ((count (merlin--count-lines type)))
-      (merlin/display-in-type-buffer type)
+    (let* ((count (merlin--count-lines type))
+          (start (car bounds))
+          (end (cdr bounds))
+          (object (buffer-substring-no-properties start end))
+          (type-message (concat object ": " type)))
+      (merlin/display-in-type-buffer type-message)
       (if (> count 8)
           (display-buffer merlin-type-buffer-name)
         (message "%s"

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -242,7 +242,11 @@ merlin-locate, see `merlin-locate-in-new-window').")
 error list changes")
 (defvar-local merlin--dwimed nil
   "Remember if we used dwim for the current completion or not")
-
+(defconst merlin--default-mode-line mode-line-format
+  "Remember the default mode line to restore later")
+(defvar-local merlin--temporary-mode-line-timeout 20
+  "Timeout that the temporarily changed mode-line will be
+reverted back to default")
 
 ;;;;;;;;;;;
 ;; UTILS ;;
@@ -1179,6 +1183,17 @@ prefix of `bar' is `'."
 ;; EXPRESSION TYPING ;;
 ;;;;;;;;;;;;;;;;;;;;;;;
 
+(defun merlin--display-temporary-mode-line (text time)
+  "Display TEXT in mode line for TIME seconds."
+  (let ((buf (current-buffer)))
+    (setq mode-line-format text)
+    (run-at-time time nil
+                 (lambda (v b)
+                   (with-current-buffer b
+                     (setq mode-line-format v)
+                     (force-mode-line-update)))
+                 merlin--default-mode-line buf)))
+
 (defun merlin--type-expression (exp callback-if-success &optional callback-if-exn)
   "Get the type of EXP inside the local context."
   (when exp (merlin/send-command-async
@@ -1196,6 +1211,8 @@ If QUIET is non nil, then an overlay and the merlin types can be used."
           (end (cdr bounds))
           (object (buffer-substring-no-properties start end))
           (type-message (concat object ": " type)))
+      (merlin--display-temporary-mode-line type-message
+                                           merlin--temporary-mode-line-timeout)
       (merlin/display-in-type-buffer type-message)
       (if (> count 8)
           (display-buffer merlin-type-buffer-name)


### PR DESCRIPTION
Hi,

I want to contribute my implementation of the imenu feature to your excellent Merlin-Emacs mode. The reason I implemented this feature is because:
  - The default imenu of Tuareg-mode is quite slow
  - The Merlin-Emacs mode hasn't supported imenu yet, whereas code outline is ready by Merlin

## Description and usage ##

Structure of the merline-imenu module is as follows: 

* Since the code outline returned by Merlin can be big, so I change two thresholds of Emacs, but I'm really not sure about the side effect.

```
(setq max-lisp-eval-depth 10000)
(setq max-specpdl-size 10000)
```

* The core function is  `merlin-imenu-create-index`, which create an index function for imenu

* Users can decide which imenu feature that they want to use by executing one of the two functions:
`merlin-use-merlin-imenu` or `merlin-use-tuareg-imenu`. These functions simply assign the indexing function of either `merlin-imenu` or `tuareg-imenu` to the built-in variable `imenu-create-index-function` of imenu-mode

* For my personal use, I add a hook to always enable `merlin-imenu` when switching to tuareg-mode because `merlin-imenu` is really faster than `tuareg-imenu` (see experiment below).

* Imenu can be invoke as usual. For example, I usually use `helm-semantic-or-imenu` to view the list of outline.

## Experiment ##
I tested both the Tuareg-imenu and Merlin-imenu with the module [config.ml] (https://github.com/facebook/infer/blob/master/infer/src/backend/config.ml)
(~1500 lines of code) from the Facebook's Infer tool in my machine (CPU: Core i5 3.2Ghz, RAM: 8GB): 
 - the default Tuareg-imenu spent 4.7s to read the outline
 - whereas the Merlin-imenu took only 0.05s (Thanks to the excellent Merlin-mode)

Source code that printing executing time is commented out in the file `merline-imenu.el`. However, I also added detail comments how to use it.  For example, the detail log can be printed as follows:
(2 lines: Time spent by ...)

```
Merlin: tuareg-imenu is selected, rescanning buffer...
Saving file /home/trungtq/workspace/ocaml/infer/infer/src/backend/config.ml...
Wrote /home/trungtq/workspace/ocaml/infer/infer/src/backend/config.ml
Searching definitions...done
** Time spent by Tuareg-Imenu: 4.713094s
Merlin: merlin-imenu is selected, rescanning buffer...
Saving file /home/trungtq/workspace/ocaml/infer/infer/src/backend/config.ml...
Wrote /home/trungtq/workspace/ocaml/infer/infer/src/backend/config.ml
** Time spent by Merlin-Imenu: 0.049508s
```

## Illustration ##

Below are illustration in my Emacs with when invoking `helm-semantic-or-imenu` with `merlin-imenu` and `tuareg-imenu`, subsequently:

Note that `meline-imenu` returns more complete outline with 354 candidates, whereas `tuareg-imenu` found only 121.

(I think the reason that `tuareg-imenu` is slower, and less complete than `merlin-imenu` is because the `tuareg-imenu` uses regular expression to find code outline, whereas `merlin-imenu` inherits the entire information found by Ocamlmerlin parser)


### Merlin-imenu ###
![imenu-merlin](https://cloud.githubusercontent.com/assets/20593743/17243636/6dae2d00-55b0-11e6-9fab-1f73e8174a89.png)

### Tuareg-imenu ###
![imenu-tuareg](https://cloud.githubusercontent.com/assets/20593743/17243643/745131ca-55b0-11e6-8471-16478aa6600f.png)



Bests,
Trung.